### PR TITLE
reduce |E| for binary search

### DIFF
--- a/main.c
+++ b/main.c
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
             }
         int p = 0;
         for(int i=0;i<n;i++){
-            for(int j=0;j<n;j++){
+            for(int j=i+1;j<n;j++){
                 costs[p] = matrix[i][j];
                 p++;
             }


### PR DESCRIPTION
Due it works only for asymmetric instances we only have (n - 1) * n / 2 vertices instead of n^2 vertices to be ordered. 
In my computer for instance kroa100 it reduces from 0.005 mlls to 0.003 in most runnings.